### PR TITLE
[BUGFIX] Explicit typecast for singlePid

### DIFF
--- a/Classes/ViewHelpers/Widget/Controller/MapController.php
+++ b/Classes/ViewHelpers/Widget/Controller/MapController.php
@@ -144,7 +144,7 @@ class MapController extends AbstractWidgetController
 
             // Current marker does not need detail link
             if (false === $isCurrentMarker) {
-                $detailsPid = $this->settings['singlePid'] ?? $this->getTyposcriptFrontendController()->id;
+                $detailsPid = (int)$this->settings['singlePid'] ?? $this->getTyposcriptFrontendController()->id;
                 $uriBuilder = $this->controllerContext->getUriBuilder();
                 $infoWindowParameters['detailLink'] = $uriBuilder->reset()->setTargetPageUid($detailsPid)->uriFor(
                     'show',


### PR DESCRIPTION
Because typoscript values are interpreted as strings, we have to typecast settings.singlePid so that UriBuilder->setTargetPageUid() will receive the correctly typed value.

fixes #29 