### PR TITLE
fixes import for images without querystring

### DIFF
--- a/Classes/Domain/Model/ValueObject/ImageLink.php
+++ b/Classes/Domain/Model/ValueObject/ImageLink.php
@@ -50,6 +50,8 @@ class ImageLink
         if (array_key_exists('query', $urlSegments)) {
             parse_str($urlSegments['query'], $querySegments);
             $this->identifier = $querySegments['id'];
+        } else {
+            $this->identifier = $externalUrl;
         }
     }
 }


### PR DESCRIPTION
new (logo) images for beratungsstellensuche entries will be assigned correctly even when the lack a querystring. instead of using an empty value as identifier (and thus assigning a wrong image), the whole path is taken as the identifier
if a new remote file is / should be fetched, the security check via \TYPO3\CMS\Core\Resource\Security\FileNameValidator fails on TYPO3 v9 instances, because this class is only available since TPO3 v10, so we fall back to GeneralUtility::verifyFilenameAgainstDenyPattern()

fixes #31 