### PR TITLE
configures notice as richtext field

### DIFF
--- a/Configuration/TCA/tx_bzgaberatungsstellensuche_domain_model_entry.php
+++ b/Configuration/TCA/tx_bzgaberatungsstellensuche_domain_model_entry.php
@@ -219,6 +219,8 @@ return [
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
+                'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
+                'enableRichtext' => true,
             ],
         ],
         'website' => [


### PR DESCRIPTION
because the node Hinweistext now consists of CDATA escaped data with html tags

fixes #33