### PR TITLE
[TASK] Fix Unit tests

### DIFF
--- a/Tests/Unit/Factories/GeocoderFactoryTest.php
+++ b/Tests/Unit/Factories/GeocoderFactoryTest.php
@@ -16,6 +16,7 @@ use Geocoder\Provider\GoogleMaps\GoogleMaps;
 use Geocoder\Provider\Nominatim\Nominatim;
 use Geocoder\Provider\Provider;
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 class GeocoderFactoryTest extends UnitTestCase
@@ -29,6 +30,8 @@ class GeocoderFactoryTest extends UnitTestCase
     protected function setUp(): void
     {
         $this->httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
+
+        self::assertInstanceOf(ClientInterface::class, $this->httpClient);
         parent::setUp();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "geocoder-php/google-maps-provider": "^4.4",
-        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0",
         "php-http/message": "^1.7",
         "geocoder-php/nominatim-provider": "^5.1"
     },
@@ -52,7 +52,8 @@
         "saschaegerer/phpstan-typo3": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "typo3/coding-standards": "^0.2.0",
-        "rector/rector": "^0.12.13"
+        "rector/rector": "^0.12.13",
+        "phpspec/prophecy": "^1.16"
     },
     "replace": {
         "typo3-ter/bzga-beratungsstellensuche": "self.version"


### PR DESCRIPTION
Geocoder\Provider\GoogleMaps\GoogleMaps expects ClientInterface not HttpClient. Therefore we need to use php-http/httplug 2.0 which means we have to use php-http/guzzle6-adapter 2.0