### PR TITLE
[TASK] Create failing tests for Import of Beratungsarten

### DIFF
--- a/Tests/Functional/Domain/Repository/EntryRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/EntryRepositoryTest.php
@@ -153,6 +153,7 @@ class EntryRepositoryTest extends FunctionalTestCase
 
     public function tearDown(): void
     {
+        parent::tearDown();
         unset($this->entryRepository);
     }
 }

--- a/Tests/Functional/Fixtures/Import/beratungsstellen.xml
+++ b/Tests/Functional/Fixtures/Import/beratungsstellen.xml
@@ -4,44 +4,80 @@
     <entrys>
         <entry>
             <index>2619</index>
-            <titel>Titel der Beratungsstelle</titel>
+            <title>Fachstelle f&#xFC;r Sucht und Suchtpr&#xE4;vention</title>
             <untertitel></untertitel>
-            <ansprechpartner>Max Mustermann</ansprechpartner>
-            <link>http://meine-domain.com.de/</link>
-            <plz>33333</plz>
-            <ort>Musterstadt</ort>
-            <bundesland>1</bundesland>
-            <strasse>Musterstraße 1</strasse>
-            <mapx>8.58175</mapx>
-            <mapy>48.77265</mapy>
+            <link>https://adressen.bzga.de/node/42</link>
+            <plz>40547</plz>
+            <ort>D&#xFC;sseldorf</ort>
+            <bundesland>10</bundesland>
+            <strasse>Musterstra&#xDF;e 1</strasse>
+            <mapx>8.12345</mapx>
+            <mapy>51.11111</mapy>
             <telefon>07051 924870</telefon>
-            <fax>07051 92487226</fax>
+            <fax></fax>
             <email>max.mustermann@domain.com</email>
-            <traeger>Träger der Beratungsstelle</traeger>
-            <website>www.domain.de</website>
-            <beratertelefon>000000000</beratertelefon>
-            <hinweistext>Di.15.00h 16.00h</hinweistext>
-            <beratungsschein>1</beratungsschein>
-            <angebot><![CDATA[<p></p>]]></angebot>
-            <logo></logo>
-            <konfession>1</konfession>
+            <traeger></traeger>
+            <website>http://www.domain.de</website>
+            <beratertelefon></beratertelefon>
+            <hinweistext>10:00 Uhr bis 22:00 Uhr Montag bis Sonntag</hinweistext>
+            <beratungsschein></beratungsschein>
+            <kostenuebernahmeverhuetung></kostenuebernahmeverhuetung>
+            <logo/>
+            <konfession></konfession>
             <beratungsart>
-                <index>2</index>
                 <index>1</index>
+                <index>2</index>
             </beratungsart>
-            <verband>Verband der Beratungsstelle</verband>
-            <kontaktform>0</kontaktform>
+            <verband></verband>
+        </entry>
+        <entry>
+            <index>3108</index>
+            <title><![CDATA[Frauen & Mädchen Beratungsstelle]]></title>
+            <untertitel></untertitel>
+            <link>https://adressen.bzga.de/node/123</link>
+            <plz>90429</plz>
+            <ort>N&#xFC;rnberg</ort>
+            <bundesland>2</bundesland>
+            <strasse>F&#xFC;rther Stra&#xDF;e 123</strasse>
+            <mapx>11.12345</mapx>
+            <mapy>49.22222</mapy>
+            <telefon>0911 12345</telefon>
+            <fax>0911 12345</fax>
+            <email>info@example.org</email>
+            <traeger></traeger>
+            <website>http://www.example.org</website>
+            <beratertelefon></beratertelefon>
+            <hinweistext>Sprechzeiten:
+                Montag 10:00 - 12:00 Uhr,
+                Dienstag 14:00 - 16:00 Uhr,
+                Donnerstag 15:00 - 17:00 Uhr
+            </hinweistext>
+            <beratungsschein></beratungsschein>
+            <kostenuebernahmeverhuetung></kostenuebernahmeverhuetung>
+            <logo/>
+            <konfession></konfession>
+            <beratungsart>
+                <index>1</index>
+                <index>2</index>
+            </beratungsart>
+            <verband></verband>
         </entry>
     </entrys>
     <beratungsarten>
         <beratungsart>
             <index>1</index>
-            <sort>2</sort>persönliche Beratung</beratungsart>
+            <sort>?</sort>
+            <label>Pers&#xF6;nliche Beratung</label>
+        </beratungsart>
         <beratungsart>
             <index>2</index>
-            <sort>3</sort>telefonische Beratung</beratungsart>
+            <sort>?</sort>
+            <label>Einzelberatung</label>
+        </beratungsart>
         <beratungsart>
             <index>3</index>
-            <sort>1</sort>Online-Beratung</beratungsart>
+            <sort>?</sort>
+            <label>Gruppenberatung</label>
+        </beratungsart>
     </beratungsarten>
 </beratungsstellen>

--- a/Tests/Functional/Service/Importer/XmlImporterTest.php
+++ b/Tests/Functional/Service/Importer/XmlImporterTest.php
@@ -86,16 +86,18 @@ class XmlImporterTest extends FunctionalTestCase
         $this->subject->persist();
 
         self::assertEquals(3, $this->selectCount('*', 'tx_bzgaberatungsstellensuche_domain_model_category'));
-        self::assertEquals(1, $this->selectCount('*', 'tx_bzgaberatungsstellensuche_domain_model_entry'));
-        self::assertEquals(2, $this->selectCount('*', 'tx_bzgaberatungsstellensuche_entry_category_mm'));
+        self::assertEquals(2, $this->selectCount('*', 'tx_bzgaberatungsstellensuche_domain_model_entry'));
+        self::assertEquals(4, $this->selectCount('*', 'tx_bzgaberatungsstellensuche_entry_category_mm'));
 
-        self::assertEquals('Titel der Beratungsstelle', $this->select('title', 'tx_bzgaberatungsstellensuche_domain_model_entry', 1));
-        self::assertEquals('8.58175', $this->select('longitude', 'tx_bzgaberatungsstellensuche_domain_model_entry', 1));
+        self::assertEquals('Fachstelle für Sucht und Suchtprävention', $this->select('title', 'tx_bzgaberatungsstellensuche_domain_model_entry', 1));
+        self::assertEquals('Frauen & Mädchen Beratungsstelle', $this->select('title', 'tx_bzgaberatungsstellensuche_domain_model_entry', 2));
+        self::assertEquals('8.12345', $this->select('longitude', 'tx_bzgaberatungsstellensuche_domain_model_entry', 1));
         self::assertEquals('Online-Beratung', $this->select('title', 'tx_bzgaberatungsstellensuche_domain_model_category', 3));
     }
 
     public function tearDown(): void
     {
+        parent::tearDown();
         unset($this->subject);
     }
 }


### PR DESCRIPTION
It seems like the provided Dataformat has changed.  The title of a beratungsart is now wrapped in a label tag. Therefore the import fails.

I also updated the dataset with some anonymized real time data how it is supplied right now.

It seems like I do not understand the serializer sufficiently to provide a solution for this problem.

Added parent call to all tearDown methods. Without the following error happened after changing the data set:

```
Bzga\BzgaBeratungsstellensuche\Tests\Functional\Service\Importer\XmlImporterTest::importFromFile
PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in Standard input code:430
Stack trace:
#0 Standard input code(430): serialize(Array)
#1 Standard input code(705): __phpunit_run_isolated_test()
#2 {main}
  thrown in Standard input code on line 430
```